### PR TITLE
Make the javadoc name query lowercase

### DIFF
--- a/discord/src/main/java/me/piggypiglet/docdex/bot/commands/implementations/documentation/DocumentationCommand.java
+++ b/discord/src/main/java/me/piggypiglet/docdex/bot/commands/implementations/documentation/DocumentationCommand.java
@@ -110,7 +110,7 @@ public abstract class DocumentationCommand extends JDACommand {
         }
 
         final IndexURLBuilder urlBuilder = new IndexURLBuilder()
-                .javadoc(javadoc)
+                .javadoc(javadoc.toLowerCase())
                 .query(query);
 
         if (limit.get() != -1) {


### PR DESCRIPTION
Didn't make the `javadoc` string lowercase so it's still preserved when showing in an embed

mm :^)